### PR TITLE
feat: Launch Spectator Mode for Online Public Games (v3.0.0)

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -1,0 +1,55 @@
+# 📜 Patch Notes Archive
+
+All previous release notes for Connect 4: AI Showdown.
+
+---
+
+## 🛠 Patch Notes — April 29, 2025
+
+✅ **New Features (v3.0.0)**  
+- 🎥 Added Spectate Mode for public games
+- 📋 Separate modal flows for Spectators vs. Players
+- 🛠 Restored circle selection indicators in public/spectate lists
+- 👁 Sorted spectators list with "(You)" always first
+- 🔇 Removed stale toast messages across screens
+- 🎵 Countdown sound effect now synced with visuals
+- 🛡️ Defensive server-side socket cleanup and player state fixes
+- 🧼 Resolved stale board state after rematches / name changes
+- 🧭 New display name persistence logic for modal flow
+- 🛰️ Socket ID tracking to differentiate spectators accurately
+- 🛡️ Fixed "(You)" label bug when duplicate names exist
+- 🧹 General Code cleanup
+- 🎨 Highlights players winning moves 
+
+---
+
+## 🛠 Patch Notes — April 23, 2025
+
+- ✨ Victory animation added with blinking glow effect
+- 🎵 Lowered volume of victory/defeat sounds to improve user experience across devices.
+- 🎨 Extended last-move highlight to support **both players** (not just AI).
+- 🧠 Fixed "Impossible" AI bugs
+- 🎶 Sound effect additions (victory, defeat, move clinks)
+- 🔄 Fully implemented online rematch system with countdown
+-  🧹 Fixed issue where public game rooms weren't being cleaned up when a host returned to the main menu.
+- 🧹  Improved socket `leaveRoom` and `disconnect` logic for proper lobby list updates.
+- 🔄 Removed manual "Refresh" button from the Public Game Lobby. Replaced with a dynamic “🟢 Auto-refreshing” status icon and pulsing dot to signal live updates.
+
+---
+
+## 🛠 Patch Notes — April 15, 2025
+ **Changes:**
+- Resolved a number of key multiplayer bugs:
+  - Fixed bug where both online players had the same name
+  - Fixed room state not cleaning up properly after host/guest disconnection
+  - Fixed bug where name from previous match would persist incorrectly
+  - Fixed rematch bugs across all modes (AI, Local, Online)
+- AI Rematch Flow:
+  - Added prompt to allow player to **keep the same AI difficulty** or **change to a different one** on rematch
+  - Disabled selecting the same level again during difficulty selection
+- General:
+  - Prevented confetti from appearing on load
+  - Correctly highlighted last move for AI
+  - Resolved casing mismatches and React hook dependency warnings
+
+---

--- a/README.md
+++ b/README.md
@@ -10,7 +10,35 @@ _(Previously on Netlify — now hosted on Render with a full backend server)_
 
 ---
 
-### 🌐 0. NEW: Online Multiplayer Mode 🎮
+### 🌐 0. NEW: Spectate Online Public Games 👁️
+-  Browse and spectate active public games in real time
+- Watch games live without participating or disrupting play
+
+✅ **Changes:**
+- Added full **Spectator Mode** for online public games:
+  - Dedicated Spectator UI showing Players and Spectators
+  - Smooth transition between spectating and playing
+  - New modals for "Spectate Another Game" and "Play Your Own Game"
+  - Smart handling of spectator disconnections and room closures
+  - Fixed '(You)' label bugs  and name collision issues
+  - Improved display name persistence and state cleanup for spectators
+
+📌 **Files Affected:**
+- `App.js`
+- `GameMenu.js`
+- `OnlineMenu.js`
+- `server.js`
+- `useSocketListeners.js`
+- `EnterNameScreen.js`
+- `gameReset.js`
+
+💡 **Why:**  
+To make online play more dynamic and engaging. Even if you aren't competing, you can still watch the action live!
+
+---
+
+
+### 🌐 1. Online Multiplayer Mode 🎮
 ✅ **Changes:**
 - Added full **online multiplayer support**:
   - Create or join a private room via code
@@ -30,23 +58,16 @@ To turn the game into a social, real-time experience. Challenge your friends or 
 
 ---
 
-### 🧠 1. Game Modes Feature
+### 🧠 2. Game Modes Feature
 ✅ **Changes:**
 - Added a game mode menu with three options:
   - 🧑‍🤝‍🧑 Local Play vs Human
   - 🤖 Play vs AI
   - 🌐 Play Online
 
-📌 **Files Affected:**
-- `App.js`
-- `GameMenu.js`
-
-💡 **Why:**
-To support every kind of player: solo, local, and online.
-
 ---
 
-### 🤖 2. AI Difficulty Options
+### 🤖 3. AI Difficulty Options
 ✅ **Changes:**
 - Four levels: Easy, Medium, Hard, Impossible
 - Logic scales from random to perfect Minimax + Alpha-Beta play
@@ -59,7 +80,7 @@ To showcase AI design and make the game engaging at all skill levels.
 
 ---
 
-### ✨ 3. Winner UI & Confetti
+### ✨ 4. Winner UI & Confetti
 ✅ **Changes:**
 - `WinnerBanner.js`
 - Confetti triggered only when a player wins (using `react-confetti`)
@@ -67,55 +88,21 @@ To showcase AI design and make the game engaging at all skill levels.
 
 ---
 
-### 🎨 4. UI/UX Polish
-✅ Animated tokens, glowing title, button hovers, `Poppins` font, polished layout, and mobile support.
+### 🎨 5. Visual and Audio Polish
+- 🎨 Clean, responsive UI
+- 🔊 Sound effects: victory, defeat, move clinks
+- 🎆 Confetti win animation
+- 🕹️ Player labels and real-time game state
 
 ---
 
-### 🧼 5. Refactor & Modularization
-✅ Organized the codebase into `/components`, `/hooks`, `/utils`
-
----
-
-### 🐛 6. Bug Fixes
-✅ **Changes:**
-- Resolved a number of key multiplayer bugs:
-  - Fixed bug where both online players had the same name
-  - Fixed room state not cleaning up properly after host/guest disconnection
-  - Fixed bug where name from previous match would persist incorrectly
-  - Fixed rematch bugs across all modes (AI, Local, Online)
-- AI Rematch Flow:
-  - Added prompt to allow player to **keep the same AI difficulty** or **change to a different one** on rematch
-  - Disabled selecting the same level again during difficulty selection
-- General:
-  - Prevented confetti from appearing on load
-  - Correctly highlighted last move for AI
-  - Resolved casing mismatches and React hook dependency warnings
-
----
-
-### 🚀 7. Impossible AI (Perfect Play Mode)
+### 🚀 6. Impossible AI (Perfect Play Mode)
 ✅ Uses full Minimax + Alpha-Beta pruning with dynamic depth and evaluation scoring
 
 ---
 
-### 💡 8. Fun Facts + Developer Touches
-✅ Rotating trivia card, subtle transitions, and little touches throughout
 
----
-
-### 🔧 9. Deployment & Hosting (NEW)
-✅ Switched from Netlify (frontend-only) to **Render** for full backend support:
-- Socket.IO server now lives in the same Render service as the React frontend
-- Simplified environment, no CORS hacks or proxies
-- Single deploy pipeline
-
-💡 **Why the switch?**
-To support real-time multiplayer, you need a persistent Node.js server — Render made full-stack deployment seamless.
-
----
-
-### 🔊 10. Sound Effects Integration
+### 🔊 7. Sound Effects Integration
 ✅ **Changes:**
 - Added custom audio to enhance feedback and immersion:
   - ✅ Victory & Defeat chimes
@@ -123,57 +110,37 @@ To support real-time multiplayer, you need a persistent Node.js server — Rende
   - ✅ Countdown ticking sound before rematch
   - ✅ Disconnect alert sound when opponent leaves
 
-📌 **Files Affected:**
-- `App.js`, `WinnerBanner.js`, and sound utility logic
-
 ---
 
 ### 🗂 Folder Structure (Simplified)
 ```
 /client         ← React frontend (builds to /client/build)
 /server.js      ← Express + Socket.IO backend
-/components     ← UI pieces (Board, Menu, WinnerBanner)
-/hooks          ← Custom hooks (AI logic)
-/utils          ← Utility functions (checkWinner, etc.)
+/components     ← UI pieces (Board, Menu, WinnerBanner,OnlineMenu,EnterNameScreen)
+/hooks          ← Custom hooks (AI logic,FunFacts,SocketListeners)
+/utils          ← Utility functions (checkWinner, gameReset, gameLogic, etc)
 ```
 
 ---
 
-### 📌 Current Version: `v2.0.1`  
+### 📌 Current Version: `v3.0.0`  
 - `v1.x`: AI-focused single-player release  
-- `v2.0`: Online Multiplayer + Render Hosting
+- `v2.x`: Online Multiplayer + Render Hosting  
+- `v3.0`: Spectate Mode for Public Online Games 🎥
+
 ---
 
-### 🛠 April 23rd Patch Notes — Quality of Life & Bug Fix Roundup
+### 🛠Latest Patch — April 29, 2025 - Spectator Mode Now Live
 
-✅ **Changes & Improvements:**
+> 📄 Full changelog in [`/PATCH_NOTES.md`](./PATCH_NOTES.md)
 
-- 🎵 **Victory & Defeat Sound Tweaks**  
-  - Lowered volume of victory/defeat sounds to improve user experience across devices.
+✅ Highlights:
+- Spectator Mode
+- Countdown sound fix
+- Highlight Winning Moves
+- New Game board legend for player and spectator
+- Name modal refinements
+- Room cleanup improvements
+- ESLint and UI bugs fixed
 
-- 🧹 **Online Room Cleanup Reliability**  
-  - Fixed issue where public game rooms weren't being cleaned up when a host returned to the main menu.
-  - Improved socket `leaveRoom` and `disconnect` logic for proper lobby list updates.
-
-- 🎯 **Last Move Highlighting (Now for Everyone)**  
-  - Extended last-move highlight to support **both players** (not just AI).
-  - Automatically disables highlight when a winner is declared.
-
-- 🏆 **Winning Line Visuals**
-  - Game now visually highlights **all four winning cells** using blinking animation and colored glow (red or goldenrod based on player).
-  - Fully integrated with `checkWinner` logic which now returns both the winner and the winning cell coordinates.
-
-- 🎨 **UI & CSS Enhancements**
-  - Refined `winning-cell` styling for clarity: smoother blink, added soft glow, subtle scale pop.
-  - Fixed animation clash between `last-move` and `winning-cell`.
-
-- 🔄 **Auto-Refreshing Lobby Indicator**
-  - Removed manual "Refresh" button from the Public Game Lobby.
-  - Replaced with a dynamic “🟢 Auto-refreshing” status icon and pulsing dot to signal live updates.
-
-✅ **Files Touched:**
-- `App.js`, `Board.js`, `Cell.js`, `gameLogic.js`, `useAI.js`, `GameMenu.js`, `server.js`
-- CSS: `.winning-cell`, `.last-move`, `@keyframes`, and added `.auto-refresh-indicator`
-
-💡 **Why?**  
-To elevate visual clarity, game feedback, and reliability; especially for online play and AI challenge integrity.
+---

--- a/my-connect-react/client/src/App.css
+++ b/my-connect-react/client/src/App.css
@@ -127,16 +127,18 @@ select {
 }
 
 .winner-banner {
-  font-size: 2rem;
-  font-weight: 700;
+  font-size: 1.5rem;
+  font-weight: 600;
   color: #fff;
   background-color: #28a745;
-  padding: 15px 25px;
+  padding: 10px 20px;
   border-radius: 8px;
   text-align: center;
-  margin: 20px auto;
-  width: fit-content;
+  margin: 1rem auto;
+  width: max-content;
+  max-width: 90%;
   animation: pulse 1s ease-in-out infinite alternate;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
 @keyframes pulse {
@@ -537,3 +539,205 @@ select {
     opacity: 0.6;
   }
 }
+.player-container {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  background-color: #0c2a45;
+  border-radius: 12px;
+  padding: 12px 16px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
+  z-index: 5;
+  max-width: 250px;
+}
+
+.player-title {
+  font-weight: bold;
+  color: #fff;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.player-title .gamepad-icon {
+  margin-right: 6px;
+}
+
+
+.player-pill-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.player-pill {
+  color: #111;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-align: center;
+  font-weight: 500;
+}
+
+.red-pill {
+  background-color: red;
+}
+
+.yellow-pill {
+  background-color: gold;
+}
+
+/* Spectator container styles (unchanged if already applied) */
+.spectator-container {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background-color: #0c2a45;
+  border-radius: 12px;
+  padding: 12px 16px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
+  transition: width 0.3s ease, padding 0.3s ease;
+  z-index: 5;
+  width: 130px; /* Enough for 👁 Spectators (N) + dot */
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.spectator-container:hover {
+  width: auto;
+  max-width: 260px;        
+  padding-right: 16px;
+}
+.spectator-title .pulse-dot {
+  width: 6px;
+  height: 6px;
+  background-color: #2cc3ff;
+  border-radius: 50%;
+  margin-left: 6px;
+  animation: pulse 1.5s infinite;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.6);
+    opacity: 0.2;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+}
+/* Spectator pill list is hidden by default */
+.spectator-pill-container {
+  display: none;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+  justify-content: space-between; 
+  width: 240px;
+  position: relative;
+}
+
+/* On hover, show the pills */
+.spectator-container:hover .spectator-pill-container {
+  display: flex;
+}
+
+/* Spectator title line (👁 + Spectators N) */
+.spectator-title {
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  color: #fff;
+  font-size: 14px;
+}
+
+.spectator-title .eye-icon {
+  margin-right: 6px;
+}
+
+/* Each pill */
+.spectator-pill {
+  background-color: #2c3e50;
+  color: #fff;
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  white-space: nowrap;
+  width: 48%;
+  text-align: center;
+  box-sizing: border-box;
+}
+/* Center last spectator pill if it's alone in the row (for odd count) */
+.spectator-pill-container .spectator-pill:nth-last-child(1):nth-child(odd) {
+  margin-left: auto;
+  margin-right: auto;
+}
+.fullscreen-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100%;
+}
+.menu-title-top {
+  position: absolute;
+  top: 2rem;
+  text-align: center;
+  width: 100%;
+}
+
+.online-menu-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-top: 40px;
+}
+.enter-name-card {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 40px 50px;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(5px);
+  text-align: center;
+  animation: fadeIn 0.8s ease-in-out both;
+  position: relative;
+}
+
+.enter-name-card input {
+  margin-top: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 10px;
+  font-size: 1.1rem;
+  border-radius: 8px;
+  border: none;
+  width: 100%;
+  max-width: 300px;
+}
+
+.enter-name-card button {
+  margin-top: 1rem;
+  padding: 12px 24px;
+  font-size: 1.1em;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background-color: #00b4d8;
+  color: white;
+  transition: all 0.3s ease;
+}
+
+.enter-name-card button:hover {
+  background-color: #0096c7;
+  transform: scale(1.05);
+  box-shadow: 0 0 8px 2px rgba(0, 180, 216, 0.6);
+}
+

--- a/my-connect-react/client/src/components/EnterNameScreen.js
+++ b/my-connect-react/client/src/components/EnterNameScreen.js
@@ -1,0 +1,67 @@
+// src/components/EnterNameScreen.js
+import React, { useState, useEffect } from 'react';
+
+const EnterNameScreen = ({
+  setDisplayName,
+  setMenuScreen,
+  setIsOnlineModeChosen,
+  setIsHumanModeChosen,
+  hasSetDisplayNameRef, 
+}) => {
+  const [inputName, setInputName] = useState('');
+
+  useEffect(() => {
+    setInputName(''); // Reset cleanly when screen is mounted
+  }, []);
+
+  const handleContinue = () => {
+    const trimmed = inputName.trim();
+    if (!trimmed) {
+      alert('Please enter a valid display name.');
+      return;
+    }
+    console.log('🎯 Continuing with name:', trimmed);
+    setDisplayName(trimmed);
+    hasSetDisplayNameRef.current = true;
+    setIsHumanModeChosen(true);
+    setIsOnlineModeChosen(true);
+    setMenuScreen('hostjoin');
+  };
+
+  const handleBack = () => {
+    console.log('🔙 Going back to Local/Online screen');
+    setMenuScreen('localOrOnline');
+    setIsOnlineModeChosen(false);
+  };
+
+  return (
+    <div className="fullscreen-center">
+      <button
+        className="back-button"
+        onClick={handleBack}
+      >
+        ⬅ Back
+      </button>
+
+      <div className="menu-card">
+        <h2>Enter Display Name</h2>
+        <input
+          type="text"
+          placeholder="Your name"
+          value={inputName}
+          onChange={(e) => setInputName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleContinue();
+            }
+          }}
+          className="input-display-name"
+        />
+        <button onClick={handleContinue}>Continue</button>
+      </div>
+    </div>
+  );
+};
+
+export default EnterNameScreen;

--- a/my-connect-react/client/src/components/OnlineMenu.js
+++ b/my-connect-react/client/src/components/OnlineMenu.js
@@ -1,0 +1,255 @@
+// src/components/OnlineMenu.js
+import React, { useState, useEffect } from 'react';
+import socket from '../socket';
+
+const OnlineMenu = ({
+  displayName,
+  setDisplayName,
+  setMenuScreen,
+  menuScreen,
+  setGameMode,
+  setGameCode,
+  setIsHost,
+  setIsOnlineModeChosen,
+  parentHandleBack,
+  clearPreRoomState
+}) => {
+  const [publicGames, setPublicGames] = useState([]);
+  const [selectedGameCode, setSelectedGameCode] = useState(null);
+  const [gameCodeInput, setGameCodeInput] = useState('');
+  const [localGameCode, setLocalGameCode] = useState('');
+  const [isHostingPublic, setIsHostingPublic] = useState(null);
+
+  useEffect(() => {
+    if (menuScreen === 'publicList') {
+      socket.emit('getPublicGames', 'join');
+    } else if (menuScreen === 'spectateList') {
+      socket.emit('getPublicGames', 'spectate');
+    }
+  }, [menuScreen]);
+
+  useEffect(() => {
+    if (menuScreen !== 'spectateList') return;
+    const interval = setInterval(() => {
+      socket.emit('getPublicGames', 'spectate');
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [menuScreen]);
+
+  useEffect(() => {
+    const handleGamesList = (games) => {
+      setPublicGames(games);
+    };
+    socket.on('publicGamesList', handleGamesList);
+    return () => socket.off('publicGamesList', handleGamesList);
+  }, []);
+
+  const generateGameCode = () => {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    return Array.from({ length: 6 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+  };
+
+  const startOnlineGame = ({ isHost, code, isPublic = false }) => {
+    clearPreRoomState();
+    socket.emit(isHost ? 'createRoom' : 'joinRoom', {
+      roomCode: code,
+      name: displayName,
+      isPublic,
+    });
+    setDisplayName(displayName);
+    setGameCode(code);
+    setIsHost(isHost);
+    setGameMode('ONLINE');
+  };
+  //   const handleBack = () => {
+  //     if (menuScreen === 'hostPublicOrPrivate' || menuScreen === 'joinPublicOrPrivate' || menuScreen === 'spectateList') {
+  //       setMenuScreen('hostjoin');
+  //     } else if (menuScreen === 'host' || menuScreen === 'publicList' || menuScreen === 'join') {
+  //       if (menuScreen === 'host') {
+  //         setMenuScreen('hostPublicOrPrivate');
+  //       } else {
+  //         setMenuScreen('joinPublicOrPrivate');
+  //       }
+  //     } else {
+  //       setMenuScreen('localOrOnline');
+  //     }
+  //     setSelectedGameCode(null);
+  //   };
+
+  return (
+    <>
+      {/* 🔙 Back button (floating top-left, outside card) */}
+      <button className="back-button" onClick={parentHandleBack}>
+        ⬅ Back
+      </button>
+
+      {/* 🃏 Actual menu contents wrapped inside a card */}
+      {menuScreen === 'hostjoin' && (
+        <>
+          <button onClick={() => setMenuScreen('hostPublicOrPrivate')}>
+            Host Game
+          </button>
+          <button onClick={() => setMenuScreen('joinPublicOrPrivate')}>
+            Join Game
+          </button>
+          <button onClick={() => setMenuScreen('spectateList')}>
+            Spectate a Game
+          </button>
+        </>
+      )}
+
+      {menuScreen === 'hostPublicOrPrivate' && (
+        <>
+          <p>Would you like to host a public or private game?</p>
+          <button onClick={() => {
+            setIsHostingPublic(true);
+            setLocalGameCode(generateGameCode());
+            setMenuScreen('host');
+          }}>
+            Public Game
+          </button>
+          <button onClick={() => {
+            setIsHostingPublic(false);
+            setLocalGameCode(generateGameCode());
+            setMenuScreen('host');
+          }}>
+            Private Game
+          </button>
+        </>
+      )}
+
+      {menuScreen === 'host' && (
+        <>
+          {isHostingPublic === false && (
+            <>
+              <p>🎉 Share this code with a friend:</p>
+              <h3>{localGameCode}</h3>
+            </>
+          )}
+          <button onClick={() => startOnlineGame({ isHost: true, code: localGameCode, isPublic: isHostingPublic })}>
+            Start Game
+          </button>
+        </>
+      )}
+
+      {menuScreen === 'joinPublicOrPrivate' && (
+        <>
+          <p>How would you like to join a game?</p>
+          <button onClick={() => setMenuScreen('publicList')}>
+            Find Public Game
+          </button>
+          <button onClick={() => setMenuScreen('join')}>
+            Enter Game Code
+          </button>
+        </>
+      )}
+
+      {menuScreen === 'join' && (
+        <>
+          <input
+            type="text"
+            placeholder="Enter Game Code"
+            value={gameCodeInput}
+            onChange={(e) => setGameCodeInput(e.target.value.toUpperCase())}
+            maxLength={6}
+            className="input-game-code"
+          />
+          <button
+            onClick={() => {
+              if (gameCodeInput.trim().length === 6) {
+                clearPreRoomState();
+                startOnlineGame({ isHost: false, code: gameCodeInput });
+              } else {
+                alert('Please enter a valid 6-character game code.');
+              }
+            }}
+          >
+            Join Game
+          </button>
+        </>
+      )}
+
+      {menuScreen === 'publicList' && (
+        <>
+          <h3>Select a Public Game:</h3>
+          <div style={{ display: 'flex', justifyContent: 'center', marginTop: '8px' }}>
+            <div className="auto-refresh-indicator" title="Public game list updates in real-time.">
+              <div className="dot" /> Auto-refreshing
+            </div>
+          </div>
+          <ul className="public-game-list">
+            {publicGames.length === 0 ? (
+              <li className="public-game-item empty">No public games available.</li>
+            ) : (
+              publicGames.map((game) => (
+                <li
+                  key={game.roomCode}
+                  className={`public-game-item ${selectedGameCode === game.roomCode ? 'selected' : ''}`}
+                  onClick={() => setSelectedGameCode(game.roomCode)}
+                >
+                  <span className="custom-radio">
+                    <span className="inner-dot" />
+                  </span>
+                  <span className="game-label">{game.hostName}'s Public Game</span>
+
+                </li>
+              ))
+            )}
+          </ul>
+          <button
+            disabled={!selectedGameCode}
+            onClick={() => {
+              clearPreRoomState();
+              startOnlineGame({ isHost: false, code: selectedGameCode });
+            }}
+          >
+            Join Selected Game
+          </button>
+        </>
+      )}
+
+      {menuScreen === 'spectateList' && (
+        <>
+          <h3>Select a Game to Spectate:</h3>
+          <div style={{ display: 'flex', justifyContent: 'center', marginTop: '8px' }}>
+            <div className="auto-refresh-indicator" title="Public game list updates in real-time.">
+              <div className="dot" /> Auto-refreshing
+            </div>
+          </div>
+          <ul className="public-game-list">
+            {publicGames.length === 0 ? (
+              <li className="public-game-item empty">No public games available.</li>
+            ) : (
+              publicGames.map((game) => (
+                <li
+                  key={game.roomCode}
+                  className={`public-game-item ${selectedGameCode === game.roomCode ? 'selected' : ''}`}
+                  onClick={() => setSelectedGameCode(game.roomCode)}
+                >
+                  <span className="custom-radio">
+                    <span className="inner-dot" />
+                  </span>
+                  <span className="game-label">{game.hostName}'s Game</span>
+                </li>
+              ))
+            )}
+          </ul>
+          <button
+            disabled={!selectedGameCode}
+            onClick={() => {
+              clearPreRoomState();
+              socket.emit('joinAsSpectator', selectedGameCode, displayName || 'Unknown');
+              setDisplayName(displayName);
+              setGameCode(selectedGameCode);
+              setGameMode('SPECTATE');
+            }}
+          >
+            Spectate Selected Game
+          </button>
+        </>
+      )}
+    </>
+  );
+};
+
+export default OnlineMenu;

--- a/my-connect-react/client/src/hooks/useAIHelpers.js
+++ b/my-connect-react/client/src/hooks/useAIHelpers.js
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { makeAIMoveEasy, makeAIMoveMedium, makeAIMoveHard, makeAIMoveImpossible } from './useAI';
+
+export function useAIMove(board, handleClick) {
+  const makeAIMove = useCallback((aiDifficulty) => {
+    const AI = {
+      easy: makeAIMoveEasy,
+      medium: makeAIMoveMedium,
+      hard: makeAIMoveHard,
+      impossible: makeAIMoveImpossible,
+    };
+
+    if (AI[aiDifficulty]) {
+      AI[aiDifficulty](board, (col) => {
+        handleClick(col);
+      });
+    }
+  }, [board, handleClick]);
+
+  return { makeAIMove };
+}

--- a/my-connect-react/client/src/hooks/useFunFacts.js
+++ b/my-connect-react/client/src/hooks/useFunFacts.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+export function useFunFacts() {
+    const facts = [
+      "Connect 4 is a solved game — the first player can always win with perfect play.",
+      "The game was first solved by James Dow Allen on October 1, 1988.",
+      "There are over 4 trillion possible game board combinations.",
+      "Try to control the center column — it gives you the most winning paths.",
+      "This app includes 4 AI levels, including a Minimax-based 'Impossible' mode.",
+      "Always look for diagonal threats — many players miss them until it's too late!",
+      "The longest possible game (without a win) has 42 moves — the board completely full.",
+      "The 'Impossible' AI uses alpha-beta pruning to reduce search time while still playing optimally.",
+      "Adding difficulty-based AI was a great way to learn the Minimax algorithm!",
+      "Behind every AI move, there's a for-loop silently judging you.",
+      "If this app breaks, just pretend it's a feature."
+    ];
+  
+    const [factIndex, setFactIndex] = useState(0);
+  
+    useEffect(() => {
+      const interval = setInterval(() => {
+        setFactIndex((prev) => (prev + 1) % facts.length);
+      }, 4000);
+  
+      return () => clearInterval(interval);
+    }, [facts.length]);
+  
+    return facts[factIndex];
+  }

--- a/my-connect-react/client/src/hooks/useSocketListeners.js
+++ b/my-connect-react/client/src/hooks/useSocketListeners.js
@@ -1,0 +1,308 @@
+import { useEffect } from 'react';
+import socket from '../socket';
+
+export function useSocketListeners({
+  gameMode,
+  gameCode,
+  board,
+  setBoard,
+  setCurrentPlayer,
+  setWinner,
+  setSpectators,
+  setPlayerNames,
+  setDisplayName,
+  setOpponentName,
+  setMyPlayerNumber,
+  setMenuScreen,
+  isSpectator,
+  resetGame,
+  applyMove,
+  currentPlayerRef,
+  setCountdownText,
+  boardSyncedRef,
+  boardRef,
+  toast,
+  victoryRef,
+  countdownRef,
+  defeatRef,
+  disconnectRef,
+  isSpectatorRef,
+  setShowConfetti,
+  setRecycleConfetti,
+  setLastMove,
+  setWinningCells,
+  setRematchRequestModal,
+  setGameMode,
+  createBoard,
+  hasSetDisplayNameRef,
+  setMySocketId,
+}) {
+  useEffect(() => {
+    socket.on('connect', () => {
+      console.log('🔌 Connected with socket ID:', socket.id);
+      setMySocketId(socket.id);
+    });
+    // Room Updates
+    socket.on('roomUpdate', (data) => {
+      console.log('🟢 Room update:', data.message);
+      if (data.opponentName) {
+        setOpponentName(data.opponentName);
+      }
+    });
+
+    socket.on('errorMessage', (msg) => {
+      alert(`⚠️ ${msg}`);
+    });
+
+    socket.on('spectatorUpdate', (updatedSpectators) => {
+      console.log('👥 Updated list of spectators:', updatedSpectators);
+      setSpectators(updatedSpectators);
+    });
+
+    socket.on('currentTurnUpdate', (nextPlayer) => {
+      console.log('🔄 Updating current turn to:', nextPlayer);
+      currentPlayerRef.current = nextPlayer;
+      setCurrentPlayer(nextPlayer);
+    });
+
+    socket.on('syncBoard', ({ board, currentPlayer }) => {
+      console.log('🔄 Syncing board for new spectator:', { board, currentPlayer });
+      setBoard(board);
+      currentPlayerRef.current = currentPlayer;
+      setCurrentPlayer(currentPlayer);
+      setWinner(null);
+    });
+
+    socket.on('startRematch', () => {
+      console.log("🎬 Received 'startRematch' from server!");
+      setWinner(null);
+    
+      if (setCountdownText) {
+        const steps = ['GAME STARTS IN: 3...', '2...', '1...', 'Start!!!'];
+        let index = 0;
+    
+        setCountdownText(steps[index]); // ⬅️ Show first message immediately
+    
+        // ✅ Immediately play countdown sound for "3..."
+        if (countdownRef.current) {
+          countdownRef.current.currentTime = 0;
+          countdownRef.current.play().catch(err => {
+            console.warn("🔇 Could not play countdown sound:", err);
+          });
+        }
+    
+        const interval = setInterval(() => {
+          index++;
+    
+          if (index === steps.length) {
+            clearInterval(interval);
+            setCountdownText(null);
+            boardSyncedRef.current = false;
+    
+            const newBoard = Array(6).fill(null).map(() => Array(7).fill(null));
+            setBoard(newBoard);
+            setCurrentPlayer(1);
+            currentPlayerRef.current = 1;
+            setWinner(null);
+            setShowConfetti(false);
+            setRecycleConfetti(true);
+            setLastMove(null);
+            setWinningCells(null);
+            boardRef.current = newBoard;
+          } else {
+            setCountdownText(steps[index]);
+          }
+        }, 1000);
+      }
+    });    
+    
+
+    socket.on('playerNumber', (num) => {
+      console.log("🔢 Received playerNumber:", num);
+      setMyPlayerNumber(num);
+
+      if (num === 1) {
+        currentPlayerRef.current = 1;
+        setCurrentPlayer(1);
+      }
+    });
+
+    socket.on('playerInfo', ({ host, guest }) => {
+      console.log("🎮 Received playerInfo:", { host, guest });
+
+      const isSameName = host.trim().toLowerCase() === guest.trim().toLowerCase();
+      const labeledHost = isSameName ? `${host} (Host)` : host;
+      const labeledGuest = isSameName ? `${guest} (Joiner)` : guest;
+
+      setPlayerNames({ 1: labeledHost, 2: labeledGuest });
+    });
+
+    socket.on('roomClosed', () => {
+      const isActiveGame = gameMode === 'ONLINE' || gameMode === 'SPECTATE';
+      if (!isActiveGame) return;
+    
+      console.log("🏚 Room closed — resetting for everyone");
+      toast.dismiss(); // Clear any leftover toasts
+    
+      toast.error("⚠️ Game ended. Returning to menu...");
+    
+      setTimeout(() => {
+        resetGame({
+          createBoard,
+          setBoard,
+          setCurrentPlayer,
+          currentPlayerRef,
+          setDisplayName,
+          setOpponentName,
+          setWinner,
+          setGameMode,
+          setShowConfetti,
+          setRecycleConfetti,
+          setLastMove,
+          setMyPlayerNumber,
+          setWinningCells,
+          setSpectators,
+          hasSetDisplayNameRef,
+          setMenuScreen,
+        });
+      }, 2000);
+    });
+    
+
+    socket.on('opponentMove', ({ col, player, nextPlayer }) => {
+      console.log('📥 Received opponentMove');
+      applyMove(col, player, nextPlayer);
+    });
+
+    socket.on('rematchRequest', () => {
+      if (!isSpectatorRef.current){
+        setRematchRequestModal(true);
+      }
+    });
+
+    socket.on('rematchAccepted', () => {
+      toast.success("✅ Opponent accepted the rematch!");
+      socket.emit('startRematch', gameCode);
+    });
+
+    socket.on('rematchDeclined', () => {
+      if (gameMode !== 'ONLINE') return;
+        toast.dismiss();
+        toast.error("❌ Opponent declined the rematch. Returning to main menu...");
+        setTimeout(() => {
+          resetGame({
+            createBoard,
+            setBoard,
+            setCurrentPlayer,
+            currentPlayerRef,
+            setDisplayName,
+            setOpponentName,
+            setWinner,
+            setGameMode,
+            setShowConfetti,
+            setRecycleConfetti,
+            setLastMove,
+            setMyPlayerNumber,
+            setWinningCells,
+            setSpectators,
+            hasSetDisplayNameRef,
+            setMenuScreen,
+          });
+        }, 2000);
+      });
+      
+
+      socket.on('opponentLeft', () => {
+        if (gameMode !== 'ONLINE') return;
+        console.log("👋 Received 'opponentLeft' — opponent has left.");
+        toast.dismiss();
+      
+        const performReset = () => {
+          resetGame({
+            createBoard,
+            setBoard,
+            setCurrentPlayer,
+            currentPlayerRef,
+            setDisplayName,
+            setOpponentName,
+            setWinner,
+            setGameMode,
+            setShowConfetti,
+            setRecycleConfetti,
+            setLastMove,
+            setMyPlayerNumber,
+            setWinningCells,
+            setSpectators,
+            hasSetDisplayNameRef,
+          });
+        };
+      
+        if (isSpectatorRef.current) {
+          toast.error("⚠️ Game ended. Returning to menu...");
+          setTimeout(performReset, 2000);
+          return;
+        }
+      
+        if (disconnectRef.current) {
+          disconnectRef.current.currentTime = 0;
+          disconnectRef.current.play();
+        }
+      
+        toast.error("⚠️ Opponent has left the game. Returning to menu...");
+        setTimeout(performReset, 2000);
+      });
+      
+
+    return () => {
+      socket.off('connect');
+      socket.off('roomUpdate');
+      socket.off('errorMessage');
+      socket.off('spectatorUpdate');
+      socket.off('currentTurnUpdate');
+      socket.off('syncBoard');
+      socket.off('startRematch');
+      socket.off('playerNumber');
+      socket.off('playerInfo');
+      socket.off('roomClosed');
+      socket.off('opponentMove');
+      socket.off('rematchRequest');
+      socket.off('rematchAccepted');
+      socket.off('rematchDeclined');
+      socket.off('opponentLeft');
+    };
+}, [
+    board,
+    gameCode,
+    gameMode,
+    resetGame,
+    toast,
+    setBoard,
+    setWinner,
+    setSpectators,
+    setCurrentPlayer,
+    setPlayerNames,
+    setDisplayName,
+    setOpponentName,
+    setMyPlayerNumber,
+    setMenuScreen,
+    applyMove,
+    currentPlayerRef,
+    setCountdownText,
+    boardSyncedRef,
+    boardRef,
+    victoryRef,
+    countdownRef,
+    defeatRef,
+    disconnectRef,
+    isSpectatorRef,
+    setShowConfetti,
+    setRecycleConfetti,
+    setLastMove,
+    setWinningCells,
+    setRematchRequestModal,
+    setGameMode,
+    createBoard,
+    hasSetDisplayNameRef,
+    setMySocketId
+  ]);  
+}

--- a/my-connect-react/client/src/utils/boardUtils.js
+++ b/my-connect-react/client/src/utils/boardUtils.js
@@ -1,0 +1,6 @@
+export const NUM_ROWS = 6;
+export const NUM_COLS = 7;
+
+export function createBoard() {
+  return Array(NUM_ROWS).fill(null).map(() => Array(NUM_COLS).fill(null));
+}

--- a/my-connect-react/client/src/utils/gameLogic.js
+++ b/my-connect-react/client/src/utils/gameLogic.js
@@ -1,7 +1,4 @@
-export const createBoard = (rows = 6, cols = 7) =>
-    Array(rows).fill(null).map(() => Array(cols).fill(null));
-  
-  export const findAvailableRow = (board, col) => {
+    export const findAvailableRow = (board, col) => {
     for (let row = board.length - 1; row >= 0; row--) {
       if (board[row][col] === null) return row;
     }

--- a/my-connect-react/client/src/utils/gameReset.js
+++ b/my-connect-react/client/src/utils/gameReset.js
@@ -1,0 +1,62 @@
+import socket from '../socket';
+export function resetGame({
+    createBoard,
+    setBoard,
+    setCurrentPlayer,
+    currentPlayerRef,
+    setDisplayName,
+    setOpponentName,
+    setWinner,
+    setGameMode,
+    setShowConfetti,
+    setRecycleConfetti,
+    setLastMove,
+    setMyPlayerNumber,
+    setWinningCells,
+    setSpectators,
+    hasSetDisplayNameRef,
+    setMenuScreen,
+}) {
+    console.log('🔁 Resetting game to menu...');
+    setBoard(createBoard());
+    setCurrentPlayer(1);
+    currentPlayerRef.current = 1;
+    setDisplayName('');
+    setOpponentName('');
+    setWinner(null);
+    setGameMode(null); // Kicks back to menu
+    setShowConfetti(false);
+    setRecycleConfetti(true);
+    setLastMove(null);
+    setMyPlayerNumber(null);
+    setWinningCells(null);
+    setSpectators([]);
+    hasSetDisplayNameRef.current = false;
+    if (setMenuScreen) {
+        setMenuScreen(null); 
+    }
+}
+
+export function resetToMenu({
+    gameMode,
+    isSpectator,
+    gameCode,
+    resetGameFn,
+    setMenuScreen, 
+}) {
+    if (gameMode === 'ONLINE') {
+        const confirmLeave = window.confirm(
+            "Are you sure you want to return to the menu? This will end your current game."
+        );
+        if (!confirmLeave) return;
+
+        socket.emit('leaveRoom', gameCode);
+    }
+
+    if (isSpectator) {
+        socket.emit('leaveRoom', gameCode);
+    }
+
+    resetGameFn();
+    setMenuScreen(null); 
+}

--- a/my-connect-react/server.js
+++ b/my-connect-react/server.js
@@ -19,76 +19,165 @@ const io = new Server(server, {
 
 const roomPlayers = {}; // 🔐 Maps roomCode → { host, guest }
 
+function findAvailableRow(board, col) {
+  for (let row = board.length - 1; row >= 0; row--) {
+    if (!board[row][col]) return row;
+  }
+  return -1;
+}
+
 io.on('connection', (socket) => {
   console.log(`🟢 User connected: ${socket.id}`);
+
   function broadcastUpdatedPublicGames() {
     const publicGames = Object.entries(roomPlayers)
-      .filter(([_, data]) => data.isPublic && !data.guest)
-      .map(([code, data]) => ({ roomCode: code, hostName: data.host }));
-  
+      .filter(([code, data]) => {
+        const roomExists = io.sockets.adapter.rooms.has(code);
+        return data.isPublic && !data.guest && roomExists;
+      })
+      .map(([code, data]) => ({
+        roomCode: code,
+        hostName: data.host
+      }));
+
     io.emit('publicGamesList', publicGames);
   }
 
   socket.on('createRoom', ({ roomCode, name, isPublic }) => {
-    socket.roomCode = roomCode; // ✅ Track roomCode for this socket
+    socket.roomCode = roomCode;
     socket.join(roomCode);
-    roomPlayers[roomCode] = { host: name, isPublic };
+    socket.isSpectator = false;
+
+    roomPlayers[roomCode] = {
+      host: name,
+      hostSocket: socket.id,
+      isPublic,
+      spectators: [],
+      board: Array(6).fill(null).map(() => Array(7).fill(null)),
+      currentPlayer: 1
+    };
+
     console.log(`🏠 ${name} is hosting ${isPublic ? 'a public' : 'a private'} room: ${roomCode}`);
     io.to(roomCode).emit('roomUpdate', { message: `${name} created room.` });
 
     broadcastUpdatedPublicGames();
   });
-  socket.on('getPublicGames', () => {
+
+  socket.on('getPublicGames', (mode = 'join') => {
     const publicGames = Object.entries(roomPlayers)
-      .filter(([_, data]) => data.isPublic && !data.guest)
+      .filter(([_, data]) => {
+        if (!data.isPublic) return false;
+        if (mode === 'join') return !data.guest;
+        return true;
+      })
       .map(([code, data]) => ({ roomCode: code, hostName: data.host }));
+
     socket.emit('publicGamesList', publicGames);
+  });
+
+  socket.on('joinAsSpectator', (roomCode, name) => {
+    const room = roomPlayers[roomCode];
+    if (!room || !io.sockets.adapter.rooms.get(roomCode)) {
+      socket.emit('errorMessage', 'Game not found.');
+      return;
+    }
+
+    if (!room.spectators) room.spectators = [];
+    if (room.spectators.length >= 10) {
+      socket.emit('errorMessage', 'Room has reached max spectators.');
+      return;
+    }
+
+    socket.roomCode = roomCode;
+    socket.isSpectator = true;
+    socket.spectatorName = name;
+    socket.join(roomCode);
+    room.spectators.push({ id: socket.id, name: name || 'Unknown' });
+
+    if (room.host && room.guest) {
+      socket.emit('playerInfo', {
+        host: room.host,
+        guest: room.guest,
+        playerNumber: 0
+      });
+    }
+
+    console.log(`👁️ ${name} is now spectating room ${roomCode}`);
+    io.to(roomCode).emit('spectatorUpdate', room.spectators);
+
+    socket.emit('syncBoard', {
+      board: room.board,
+      currentPlayer: room.currentPlayer || 1
+    });
   });
 
   socket.on('joinRoom', ({ roomCode, name }) => {
     const room = io.sockets.adapter.rooms.get(roomCode);
+    const players = roomPlayers[roomCode];
 
-    if (room && room.size === 1) {
-      socket.roomCode = roomCode; // ✅ Track roomCode for this socket
-      socket.join(roomCode);
-      console.log(`🙋‍♂️ ${name} joined room ${roomCode}`);
-
-      if (!roomPlayers[roomCode]) {
-        roomPlayers[roomCode] = {};
-      }
-
-      roomPlayers[roomCode].guest = name;
-      broadcastUpdatedPublicGames();
-
-      io.to(roomCode).emit('roomUpdate', { message: `${name} joined the game!` });
-
-      const { host, guest } = roomPlayers[roomCode];
-      const sockets = [...room];
-
-      if (sockets.length === 2) {
-        io.to(sockets[0]).emit('playerInfo', {
-          myName: host,
-          opponentName: guest,
-          playerNumber: 1
-        });
-
-        io.to(sockets[1]).emit('playerInfo', {
-          myName: guest,
-          opponentName: host,
-          playerNumber: 2
-        });
-      }
-    } else {
+    if (!room || !players || players.guest) {
       socket.emit('errorMessage', 'Room is full or does not exist.');
+      return;
     }
+
+    socket.roomCode = roomCode;
+    socket.join(roomCode);
+    console.log(`🙋‍♂️ ${name} joined room ${roomCode}`);
+
+    players.guest = name;
+    socket.isSpectator = false; 
+
+    io.to(roomCode).emit('roomUpdate', { message: `${name} joined the game!` });
+
+    const socketsInRoom = [...room];
+    const playerSockets = socketsInRoom.filter(
+      id => !io.sockets.sockets.get(id)?.isSpectator
+    );
+
+    if (playerSockets.length === 2) {
+      const { host, guest } = players;
+      io.to(roomCode).emit('playerInfo', {
+        host,
+        guest
+      });
+
+      io.to(playerSockets[0]).emit('playerNumber', 1);
+      io.to(playerSockets[1]).emit('playerNumber', 2);
+      broadcastUpdatedPublicGames();
+    }
+
+    io.to(roomCode).emit('spectatorUpdate', players.spectators || []);
+     // ✅ Defensive fallback in case playerSockets.length !== 2 but both names are set
+  if (players.host && players.guest) {
+    io.to(roomCode).emit('playerInfo', {
+      host: players.host,
+      guest: players.guest
+    });
+  }
   });
 
-  socket.on('makeMove', ({ roomCode, move, nextPlayer }) => {
-    console.log(`📥 Received move for room ${roomCode}`);
-    console.log('Move details:', move);
-    console.log('Next player should be:', nextPlayer);
-    console.log(`📤 Relaying move to opponent in room ${roomCode}`);
-    socket.to(roomCode).emit('opponentMove', { ...move, nextPlayer });
+  socket.on('makeMove', ({ roomCode, move }) => {
+    const room = roomPlayers[roomCode];
+    if (!room) return;
+
+    const nextPlayer = move.player === 1 ? 2 : 1;
+    if (!room.board) {
+      room.board = Array(6).fill(null).map(() => Array(7).fill(null));
+    }
+    const row = findAvailableRow(room.board, move.col);
+    if (row !== -1) {
+      room.board[row][move.col] = move.player;
+    }
+
+    room.currentPlayer = nextPlayer;
+
+    console.log(`📤 Broadcasting move to ALL in room ${roomCode}:`, move);
+
+    io.to(roomCode).emit('opponentMove', {
+      col: move.col,
+      player: move.player,
+      nextPlayer
+    });
   });
 
   socket.on('rematchRequest', (roomCode) => {
@@ -98,7 +187,18 @@ io.on('connection', (socket) => {
 
   socket.on('startRematch', (roomCode) => {
     console.log(`🎬 Starting rematch in room ${roomCode}`);
+    const room = roomPlayers[roomCode];
+    if (!room) return;
+
+    // ✅ Clear board immediately on server
+    room.board = Array(6).fill(null).map(() => Array(7).fill(null));
+    room.currentPlayer = 1;
+
     io.to(roomCode).emit('startRematch');
+
+    if (room?.spectators) {
+      io.to(roomCode).emit('spectatorUpdate', room.spectators);
+    }
   });
 
   socket.on('rematchAccepted', (roomCode) => {
@@ -109,34 +209,67 @@ io.on('connection', (socket) => {
   socket.on('rematchDeclined', (roomCode) => {
     console.log(`❌ Rematch declined in room ${roomCode}`);
     io.to(roomCode).emit('rematchDeclined');
+    delete roomPlayers[roomCode];
+    io.to(roomCode).emit('roomClosed');
+    broadcastUpdatedPublicGames();
+  });
+  socket.on('boardReadyForSync', ({ roomCode, board, currentPlayer }) => {
+    const room = roomPlayers[roomCode];
+    if (!room) return;
+  
+    // Save new board and currentPlayer
+    room.board = board;
+    room.currentPlayer = currentPlayer;
+  
+    // Sync this new board to any new spectators that join
+    console.log(`🛰️ Server received fresh boardReadyForSync in ${roomCode}`);
   });
 
   socket.on('leaveRoom', (roomCode) => {
     console.log(`🚪 Player is leaving room ${roomCode}`);
-  
-    if (!roomPlayers[roomCode]) return;
-  
+    const room = roomPlayers[roomCode];
+    if (!room) return;
+
+    if (socket.isSpectator) {
+      room.spectators = room.spectators.filter(s => s.id !== socket.id);
+      socket.leave(roomCode);
+      io.to(roomCode).emit('spectatorUpdate', room.spectators);
+      console.log(`👁️ Spectator ${socket.spectatorName} left room ${roomCode}`);
+      return;
+    }
+
     io.to(roomCode).emit('opponentLeft');
+    io.to(roomCode).emit('roomClosed');
     delete roomPlayers[roomCode];
     socket.leave(roomCode);
-  
-    console.log(`🧹 Room ${roomCode} deleted on leave`);
+    console.log(`🧹 Room ${roomCode} deleted on player leave`);
+
     broadcastUpdatedPublicGames();
   });
-  
+
   socket.on('disconnect', () => {
     console.log(`🔴 User disconnected: ${socket.id}`);
-  
+
     const roomCode = socket.roomCode;
-    if (!roomCode || !roomPlayers[roomCode]) return;
-  
+    const roomData = roomPlayers[roomCode];
+    if (!roomCode || !roomData) return;
+
+    if (socket.isSpectator && roomData.spectators) {
+      roomData.spectators = roomData.spectators.filter(s => s.id !== socket.id);
+      io.to(roomCode).emit('spectatorUpdate', roomData.spectators);
+      console.log(`👁️ Spectator ${socket.spectatorName} left ${roomCode}`);
+      socket.leave(roomCode);
+      return;
+    }
+
     io.to(roomCode).emit('opponentLeft');
     delete roomPlayers[roomCode];
+    io.to(roomCode).emit('roomClosed');
     socket.leave(roomCode);
-  
-    console.log(`🧹 Room ${roomCode} deleted on disconnect`);
+    console.log(`🧹 Room ${roomCode} deleted after player disconnect`);
+
     broadcastUpdatedPublicGames();
-  });  
+  });
 });
 
 // Serve frontend static files in production


### PR DESCRIPTION
<!--
🎉 Spectator Mode Release — v3.0.0
-->

## 🚀 What’s New
### 🌐 Spectator Mode for Online Public Games
- Users can now **watch public games in real-time** without affecting gameplay.
- Clean, non-interactive **Spectator UI** displays:
  - 🎮 Active players (with roles)
  - 👁 List of current spectators (with “(You)” marker)
- Modal prompts let users:
  - 👓 Spectate another game
  - 🎮 Play their own game (with optional name change)

## 🛠 Fixes & Improvements
- ✅ Fixed `(You)` mislabeling for duplicate display names
- 🧼 Proper spectator removal on disconnect or name change
- 🧠 `clearRoomButKeepName()` for smooth name retention on play switch
- 🧱 Added fallback for blank display names
- 🔁 Real-time board syncing restored for rejoining spectators
- 📦 Refactored socket listener flow and backend safety checks

## 📄 Docs
- 📝 Updated `README.md` with new **Feature 0**
- 📚 Introduced `PATCH_NOTES.md` to track release history

## 🔖 Version
Bumped to `v3.0.0`

---

> This is a foundational update to multiplayer support—laying the groundwork for win/loss tracking and private game spectating in future versions.
